### PR TITLE
Hotfix/v1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog GrasPlan-website
 
+## Versie 1.5.1 2020-10-22
+### Fixed 
+* De functie `setFarmId` werd niet met await aangeroepen, terwijl dat wel nodig is
+
 ## Versie 1.5.0 2020-10-21
 ### Changed
 * De backend is nu bijgewerkt naar de laatste versie van de NMI API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog GrasPlan-website
 
+## Versie 1.5.4 2020-11-05
+### Fixed
+* Maaidatum werd niet opgeslagen
+
 ## Versie 1.5.3 2020-10-26
 ### Changed
 * De kalendar loopt nu door tot 31 oktober ipv 10 oktober

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog GrasPlan-website
 
 ## Versie 1.5.2 2020-10-23
+### Added
+* Laat bij adviseurs de naam van het bedrijf zien boven de kalender
+
 ### Fixed
 * Fix om `farm_id` weg te halen uit localStorage bij login, anders problemen met meerdere accounts
 * Fix wanneer cattle count niet bekend is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog GrasPlan-website
 
+## Versie 1.5.2 2020-10-23
+### Fixed
+* Fix om `farm_id` weg te halen uit localStorage bij login, anders problemen met meerdere accounts
+* Fix wanneer cattle count niet bekend is
+
 ## Versie 1.5.1 2020-10-22
 ### Fixed 
 * De functie `setFarmId` werd niet met await aangeroepen, terwijl dat wel nodig is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog GrasPlan-website
 
+## Versie 1.5.3 2020-10-26
+### Changed
+* De kalendar loopt nu door tot 31 oktober ipv 10 oktober
+
+### Fixed
+* Kalender liet nu niet alle details zien bij beweiden
+
 ## Versie 1.5.2 2020-10-23
 ### Added
 * Laat bij adviseurs de naam van het bedrijf zien boven de kalender

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog GrasPlan-website
 
+## Versie 1.5.5 2020-11-18
+### Fixed
+* De kalender is verlengd tot 31 november
+
 ## Versie 1.5.4 2020-11-05
 ### Fixed
 * Maaidatum werd niet opgeslagen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Versie 1.5.1 2020-10-22
 ### Fixed 
 * De functie `setFarmId` werd niet met await aangeroepen, terwijl dat wel nodig is
+* Fix om bemesting toe te voegen
 
 ## Versie 1.5.0 2020-10-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed 
 * De functie `setFarmId` werd niet met await aangeroepen, terwijl dat wel nodig is
 * Fix om bemesting toe te voegen
+* Laat veldnaam zien bij percelen
 
 ## Versie 1.5.0 2020-10-21
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grasplan",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grasplan",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grasplan",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grasplan",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grasplan",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grasplan",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "The website of GrasPlan",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grasplan",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "The website of GrasPlan",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grasplan",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "The website of GrasPlan",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grasplan",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "The website of GrasPlan",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grasplan",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "The website of GrasPlan",
   "main": "server.js",
   "scripts": {

--- a/public/js/advisor.js
+++ b/public/js/advisor.js
@@ -429,7 +429,7 @@ make_timeline = function (fields) {
       // rangeselector: selectorOptions,
       // tickformatstops: ticks,
       // rangeslider: {range: ['2020-01-01', '2021-01-01']},
-      range: ['2020-02-20', '2020-10-31'],
+      range: ['2020-02-20', '2020-11-31'],
       fixedrange: true
     },
     yaxis: {

--- a/public/js/advisor.js
+++ b/public/js/advisor.js
@@ -429,7 +429,7 @@ make_timeline = function (fields) {
       // rangeselector: selectorOptions,
       // tickformatstops: ticks,
       // rangeslider: {range: ['2020-01-01', '2021-01-01']},
-      range: ['2020-02-20', '2020-10-10'],
+      range: ['2020-02-20', '2020-10-31'],
       fixedrange: true
     },
     yaxis: {

--- a/public/js/advisor.js
+++ b/public/js/advisor.js
@@ -236,8 +236,8 @@ make_timeline = function (fields) {
           if (item.cattle_type == null) {
             item.cattle_type = "Onbekend";
           }
-          if (item.cattle_type == null) {
-            item.cattle_type = "Onbekend";
+          if (item.cattle_count == null) {
+            item.cattle_count = "Onbekend";
           }
           let x1 = formatDate(item.grazing_end_date, 0)
           if (item.grazing_end_date == item.grazing_start_date) {

--- a/public/js/advisor.js
+++ b/public/js/advisor.js
@@ -83,6 +83,7 @@ showFarm = async function (farm_sel) {
     data: { farm_id: farm_sel }
   });
   let fields = farm.data.data.field;
+  $('#name_sel_farm').text(farm.data.data.farm_name)
   make_timeline(fields);
 
   timeline_plotly.on('plotly_click', function (e) {

--- a/public/js/advisor.js
+++ b/public/js/advisor.js
@@ -1,7 +1,7 @@
 $(document).ready(async function () {
   M.AutoInit();
 
-  setFarmId()
+  await setFarmId()
 
   await fillFarmTable();
 

--- a/public/js/calendar.js
+++ b/public/js/calendar.js
@@ -550,7 +550,7 @@ make_timeline = function (fields) {
       // rangeselector: selectorOptions,
       // tickformatstops: ticks,
       // rangeslider: {range: ['2020-01-01', '2021-01-01']},
-      range: ['2020-02-20', '2020-10-10'],
+      range: ['2020-02-20', '2020-10-31'],
       fixedrange: true
     },
     yaxis: {

--- a/public/js/calendar.js
+++ b/public/js/calendar.js
@@ -1,7 +1,7 @@
 $(document).ready(async function () {
   M.AutoInit();
 
-  setFarmId()
+  await setFarmId()
 
   //  Define farm in global env
   let farm_select = await axios({

--- a/public/js/calendar.js
+++ b/public/js/calendar.js
@@ -291,7 +291,7 @@ make_timeline = function (fields) {
       showlegend: true
     },
     {
-      x: ["2020-01-10", "2020-01-10"],
+      x: ["2020-01-10", "2020-01-12"],
       perceel: 0,
       line: { "color": color_pesticide, "width": 20 },
       mode: 'lines',
@@ -550,7 +550,7 @@ make_timeline = function (fields) {
       // rangeselector: selectorOptions,
       // tickformatstops: ticks,
       // rangeslider: {range: ['2020-01-01', '2021-01-01']},
-      range: ['2020-02-20', '2020-10-31'],
+      range: ['2020-02-20', '2020-11-31'],
       fixedrange: true
     },
     yaxis: {

--- a/public/js/calendar.js
+++ b/public/js/calendar.js
@@ -356,14 +356,14 @@ make_timeline = function (fields) {
       // events for grazing
       if (zone.grazing.length > 0) {
         zone.grazing.forEach(item => {
-          if (item.lca_name_nl == null) {
-            item.lca_name_nl = "Onbekend";
+          if (item.cattle_type == null) {
+            item.cattle_type = "Onbekend";
           }
-          if (item.gra_count == null) {
-            item.gra_count = "Onbekend";
+          if (item.cattle_count == null) {
+            item.cattle_count = "Onbekend";
           }
           let x1 = formatDate(item.grazing_end_date, 0)
-          if (item.gra_end_date == item.grazing_start_date) {
+          if (item.grazing_end_date == item.grazing_start_date) {
             x1 = formatDate(item.grazing_end_date, 1);
           }
           actions.push({
@@ -382,7 +382,7 @@ make_timeline = function (fields) {
             y: [zone_list.findIndex(x => x.id == zone.zone_id) - 0.4, zone_list.findIndex(x => x.id == zone.zone_id) + 0.4],
             perceel: zone_list.findIndex(x => x.id == zone.zone_id),
             marker: { "color": color_invisible },
-            name: '<b>Begindatum beweiden:</b> ' + formatDate(item.grazing_start_date, 0) + '<br><b>Einddatum beweiden:</b> ' + formatDate(item.grazing_end_date, 0) + '<br><b>Diergroep:</b> ' + item.lca_name_nl + '<br><b>Aantal dieren:</b> ' + item.gra_count,
+            name: '<b>Begindatum beweiden:</b> ' + formatDate(item.grazing_start_date, 0) + '<br><b>Einddatum beweiden:</b> ' + formatDate(item.grazing_end_date, 0) + '<br><b>Diergroep:</b> ' + item.cattle_type + '<br><b>Aantal dieren:</b> ' + item.cattle_count,
             text: 'Beweiden',
             hoverinfo: "x+text",
             uid: "c2e171",
@@ -394,10 +394,10 @@ make_timeline = function (fields) {
       // events for fertilizing 
       if (zone.fertilization.length > 0) {
         zone.fertilization.forEach(item => {
-          if (item.prd_name == null) {
-            item.prd_name = "Onbekend";
+          if (item.fertilizer_name == null) {
+            item.fertilizer_name = "Onbekend";
           }
-          if (item.fer_amount == null) {
+          if (item.fertilization_amount == null) {
             item.fertilization_amount = "Onbekend";
           }
           actions.push({
@@ -416,7 +416,7 @@ make_timeline = function (fields) {
             y: [zone_list.findIndex(x => x.id == zone.zone_id) - 0.4, zone_list.findIndex(x => x.id == zone.zone_id) + 0.4],
             perceel: zone_list.findIndex(x => x.id == zone.zone_id),
             marker: { "color": color_invisible },
-            name: '<b>Bemestingsdatum:</b> ' + formatDate(item.fertilization_date, 0) + '<br><b>Bemestingsproduct:</b> ' + item.prd_name + '<br><b>Bemestingshoeveelheid:</b> ' + item.fertilization_amount + ' kg per hectare',
+            name: '<b>Bemestingsdatum:</b> ' + formatDate(item.fertilization_date, 0) + '<br><b>Bemestingsproduct:</b> ' + item.fertilizer_name + '<br><b>Bemestingshoeveelheid:</b> ' + item.fertilization_amount + ' kg per hectare',
             text: 'Bemesten',
             hoverinfo: "x+text",
             uid: "c2e171",

--- a/public/js/create_event.js
+++ b/public/js/create_event.js
@@ -1,7 +1,7 @@
 $(document).ready(async function () {
   M.AutoInit();
 
-  setFarmId()
+  await setFarmId()
 
   // show correct form based on user choice
   $('#event_selected').on('change', function (e) {

--- a/public/js/farm.js
+++ b/public/js/farm.js
@@ -32,7 +32,7 @@ $(document).ready(async function () {
   let geojsonLayer = new L.GeoJSON(field_polygones, {
     style: { fillColor: "#FF0000", fillOpacity: 0.8, weight: 0.5 },
     onEachFeature: function (feature, layer) {
-      layer.bindTooltip(feature.properties.fld_name, {
+      layer.bindTooltip(feature.properties.field_name, {
         permanent: false,
         direction: "center",
         className: "countryLabel"

--- a/public/js/farm.js
+++ b/public/js/farm.js
@@ -2,7 +2,7 @@ $(document).ready(async function () {
   // Initialize Materialize CSS
   M.AutoInit();
 
-  setFarmId()
+  await setFarmId()
 
   // global objects fields and zones
   let farm_select = await axios({

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -43,6 +43,7 @@ sendLogin = function () {
         if (res.data.success) {
             // Successful response
             console.log('successfull login');
+            localStorage.removeItem('farm_id');
             window.location.href = "calendar";
         } else {
             // Unsuccessful response

--- a/public/js/overzicht.js
+++ b/public/js/overzicht.js
@@ -1,7 +1,7 @@
 $(document).ready(async function () {
     M.AutoInit();
 
-    setFarmId()
+    await setFarmId()
 
     // Vul invoervelden bedrijf in met gekozen bedrijf
     const farm = await selectFarm();

--- a/public/js/percelen.js
+++ b/public/js/percelen.js
@@ -3,7 +3,7 @@ $(document).ready(async function () {
   // Initialize Materialize CSS
   M.AutoInit();
 
-  setFarmId()
+  await setFarmId()
 
   // map setup for fixed location and low zoom
   let map = setupMap();

--- a/routes/routes_api.js
+++ b/routes/routes_api.js
@@ -507,6 +507,9 @@ router.post('/api_mowing_add', function (req, res) {
     axios({
         method: 'post',
         url: base_url + 'zone/' + zone_id + '/mowing',
+        params: {
+            mowing_date: date
+        },
         headers: {
             Session: session,
             Authorization: 'Bearer ' + process.env.API_KEY

--- a/routes/routes_api.js
+++ b/routes/routes_api.js
@@ -984,7 +984,7 @@ router.post('/api_session_farm', function (req, res) {
             Authorization: 'Bearer ' + process.env.API_KEY
         }
     }).then(response => {  
-        console.log(response)
+        console.log(response.data)
         res.send({ success: true, message: 'farm_id request successfull', data: {farm_id: response.data.data.farm_id}});
     }).catch(err => {
         console.log(err);

--- a/routes/routes_api.js
+++ b/routes/routes_api.js
@@ -445,7 +445,11 @@ router.post('/api_grazing_add', function (req, res) {
     const date1 = req.body.date1;
     const date2 = req.body.date2;
     const cattle_type = req.body.cattle_type;
-    const cattle_count = req.body.cattle_count;
+    let cattle_count = req.body.cattle_count;
+    
+    if (cattle_count == '') {
+        cattle_count = null;
+    }
     
     axios({
         method: 'post',
@@ -463,7 +467,6 @@ router.post('/api_grazing_add', function (req, res) {
     }).then(response => {   
         res.send({ success: true, message: 'Add grazing succesvol', data: response.data});
     }).catch(err => {
-        console.log(err);
         console.log('Fout bij toevoegen grazing: '+ err);
         res.send({ success: false });
     });
@@ -745,7 +748,6 @@ router.get('/api_advisors_lookup', function (req, res) {
     }).then(response => {  
         res.send(response.data);
     }).catch(err => {
-        console.log(err);
         console.log('Error bij list advisors ophalen van NMI-DB '+ err);
         res.send({ success: false });
     });
@@ -768,7 +770,6 @@ router.post('/api_advisor_allow', function (req, res) {
     }).then(response => {  
         res.send(response.data);
     }).catch(err => {
-        console.log(err);
         console.log('Error bij allow advisor  '+ err);
         res.send({ success: false });
     });
@@ -791,7 +792,6 @@ router.post('/api_advisor_disallow', function (req, res) {
     }).then(response => {  
         res.send(response.data);
     }).catch(err => {
-        console.log(err);
         console.log('Error bij disallow advisor '+ err);
         res.send({ success: false });
     });
@@ -811,7 +811,6 @@ router.get('/api_advisor_select', function (req, res) {
     }).then(response => {  
         res.send(response.data);
     }).catch(err => {
-        console.log(err);
         console.log('Error bij advisor select ophalen van NMI-DB '+ err);
         res.send({ success: false });
     });
@@ -832,7 +831,6 @@ router.post('/api_advisor_farm', function (req, res) {
     }).then(response => {  
         res.send(response.data);
     }).catch(err => {
-        console.log(err);
         console.log('Error bij advisor select ophalen van NMI-DB '+ err);
         res.send({ success: false });
     });
@@ -871,7 +869,6 @@ router.get('/api_nature_lookup', function (req, res) {
     }).then(response => {  
         res.send(response.data);
     }).catch(err => {
-        console.log(err);
         console.log('Error bij list nature ophalen van NMI-DB '+ err);
         res.send({ success: false });
     });
@@ -899,7 +896,6 @@ router.post('/api_nature_add', function (req, res) {
     }).then(response => {  
         res.send(response.data);
     }).catch(err => {
-        console.log(err);
         console.log('Error bij add nature management van NMI-DB '+ err);
         res.send({ success: false });
     });
@@ -921,8 +917,7 @@ router.post('/api_nature_delete', function (req, res) {
     }).then(response => {  
         res.send({ success: true, message: 'nature deleting succesful' });
     }).catch(err => {
-        console.log(err);
-        // console.log('Error bij delete nature management van NMI-DB '+ err);
+        console.log('Error bij delete nature management van NMI-DB '+ err);
         res.send({ success: false });
     });
 });
@@ -946,7 +941,6 @@ router.post('/api_renewal_add', function (req, res) {
     }).then(response => {  
         res.send(response.data);
     }).catch(err => {
-        console.log(err);
         console.log('Error bij add grassland renewal van NMI-DB '+ err);
         res.send({ success: false });
     });
@@ -968,8 +962,7 @@ router.post('/api_grassland_renewal_delete', function (req, res) {
     }).then(response => {  
         res.send({ success: true, message: 'nature deleting succesful' });
     }).catch(err => {
-        console.log(err);
-        // console.log('Error bij delete nature management van NMI-DB '+ err);
+        console.log('Error bij delete nature management van NMI-DB '+ err);
         res.send({ success: false });
     });
 });
@@ -984,7 +977,7 @@ router.post('/api_session_farm', function (req, res) {
             Authorization: 'Bearer ' + process.env.API_KEY
         }
     }).then(response => {  
-        console.log(response.data)
+        //console.log(response.data)
         res.send({ success: true, message: 'farm_id request successfull', data: {farm_id: response.data.data.farm_id}});
     }).catch(err => {
         console.log(err);

--- a/routes/routes_api.js
+++ b/routes/routes_api.js
@@ -552,7 +552,7 @@ router.post('/api_fertilising_add', function (req, res) {
 
     axios({
         method: 'post',
-        url: base_url + 'zone/' + zone_id + ' /fertilization',
+        url: base_url + 'zone/' + zone_id + '/fertilization',
         params: {
             fertilizer_id: prd_id,
             fertilization_date: date,

--- a/views/pages/advisor.ejs
+++ b/views/pages/advisor.ejs
@@ -58,6 +58,9 @@
 
     <div class="content">
         <br>
+        <div class="container">
+            <h5 id="name_sel_farm"></h5>
+        </div>
         <div class="col offset-s6">
             <div id="timeline_plotly"> </div>
         </div>


### PR DESCRIPTION
## Versie 1.5.5 2020-11-18
### Fixed
* De kalender is verlengd tot 31 november

## Versie 1.5.4 2020-11-05
### Fixed
* Maaidatum werd niet opgeslagen

## Versie 1.5.3 2020-10-26
### Changed
* De kalendar loopt nu door tot 31 oktober ipv 10 oktober

### Fixed
* Kalender liet nu niet alle details zien bij beweiden

## Versie 1.5.2 2020-10-23
### Added
* Laat bij adviseurs de naam van het bedrijf zien boven de kalender

### Fixed
* Fix om `farm_id` weg te halen uit localStorage bij login, anders problemen met meerdere accounts
* Fix wanneer cattle count niet bekend is

## Versie 1.5.1 2020-10-22
### Fixed 
* De functie `setFarmId` werd niet met await aangeroepen, terwijl dat wel nodig is
* Fix om bemesting toe te voegen
* Laat veldnaam zien bij percelen
